### PR TITLE
Fix ChromeDriver path handling.

### DIFF
--- a/main.py
+++ b/main.py
@@ -395,7 +395,7 @@ class QzonePhotoManager:
             driver_path = local_path
         # 2. 从系统PATH查找
         else:
-            driver_path = driver_name if shutil.which(driver_name) else None
+            driver_path = shutil.which(driver_name)
 
         print("正在尝试启动 Chrome 进行登录...")
         options = webdriver.ChromeOptions()


### PR DESCRIPTION
我在 Linux 上遇到了实际已经通过 `sudo apt install python3-selenium` 安装了相关的依赖，但是脚本还是未能找到准确的路径。

<img width="802" height="285" alt="2025-10-25_23-00" src="https://github.com/user-attachments/assets/e8521125-3ad9-4cbe-b6c1-d97d203ec77c" />

```bash
tom@tomacat:~/Projects/qzone-photo-downloader$ python main.py 
成功从 config.json 加载配置。
正在尝试启动 Chrome 进行登录...
启动 ChromeDriver 失败。请确保它在您的 PATH 或脚本目录中: Message: Unable to obtain driver for chrome; For documentation on this error, please visit: https://www.selenium.dev/documentation/webdriver/troubleshooting/errors/driver_location

尝试使用的驱动路径: chromedriver
您可以从以下地址下载 ChromeDriver: https://googlechromelabs.github.io/chrome-for-testing
tom@tomacat:~/Projects/qzone-photo-downloader$ which chromedriver
/usr/bin/chromedriver
```

修改了脚本的逻辑，现在在 Linux 上也能正常运行了。我的QQ空间图片已经成功下载备份下来啦，感谢。